### PR TITLE
Make configfs-iscsi-path configurable

### DIFF
--- a/src/configfs.h
+++ b/src/configfs.h
@@ -41,6 +41,7 @@ struct portal {
 };
 
 #define ALL_TARGETS ((struct target*) 1)
+#define CONFIGFS_ISCSI_PATH    "/sys/kernel/config/target/iscsi"
 
 bool configfs_iscsi_path_exists(void);
 

--- a/src/target-isns.c
+++ b/src/target-isns.c
@@ -44,12 +44,13 @@ static struct epoll_event epoll_events[EPOLL_MAX_FD];
 static void print_usage(void)
 {
 	printf("Usage: " PROGNAME " [OPTIONS]\n"
-	       "  -i, --isns-server  Set the IP address of the iSNS server.\n"
-	       "  -p, --isns-port    Set the remote port for iSNS server.\n"
-	       "  -d, --debug        Increase the debugging level (implies -f).\n"
-	       "  -f, --foreground   Run in the foreground.\n"
-	       "  -v, --version      Print version information.\n"
-	       "  -h, --help         Print this message.\n");
+	       "  -i, --isns-server          Set the IP address of the iSNS server.\n"
+	       "  -p, --isns-port            Set the remote port for iSNS server.\n"
+	       "  -d, --debug                Increase the debugging level (implies -f).\n"
+	       "  -f, --foreground           Run in the foreground.\n"
+	       "  -s, --configfs-iscsi-path  Use alternate sys configfs iscsi path.\n"
+	       "  -v, --version              Print version information.\n"
+	       "  -h, --help                 Print this message.\n");
 }
 
 static void epoll_init_fds(void)
@@ -113,15 +114,16 @@ static bool signal_is_quit(int fd)
 
 int main(int argc, char *argv[])
 {
-	char optstring[] = "i:p:dfvh";
+	char optstring[] = "i:p:dfs:vh";
 	struct option longopts[] = {
-		{"isns-server", 1, NULL, 'i'},
-		{"isns-port",   1, NULL, 'p'},
-		{"debug",       0, NULL, 'd'},
-		{"foreground",  0, NULL, 'f'},
-		{"version",     0, NULL, 'v'},
-		{"help",        0, NULL, 'h'},
-		{NULL,          0, NULL, 0}
+		{"isns-server",		1, NULL, 'i'},
+		{"isns-port",		1, NULL, 'p'},
+		{"debug",		0, NULL, 'd'},
+		{"foreground",		0, NULL, 'f'},
+		{"configfs-iscsi-path",	1, NULL, 's'},
+		{"version",		0, NULL, 'v'},
+		{"help",		0, NULL, 'h'},
+		{NULL,			0, NULL, 0}
         };
 	int option;
 	int longindex = 0;
@@ -130,6 +132,7 @@ int main(int argc, char *argv[])
 	ssize_t nr_events;
 	bool daemon = true;
 	int ret = EXIT_FAILURE;
+	size_t configsz;
 
 	conffile_read();
 
@@ -137,10 +140,9 @@ int main(int argc, char *argv[])
 				     &longindex)) != -1) {
 		switch (option) {
 		case 'i':
-			;
-			const size_t sz = sizeof(config.isns_server);
-			strncpy(config.isns_server, optarg, sz);
-			config.isns_server[sz - 1] = '\0';
+			configsz = sizeof(config.isns_server);
+			strncpy(config.isns_server, optarg, configsz);
+			config.isns_server[configsz - 1] = '\0';
 			break;
 		case 'p':
 			sscanf(optarg, "%hu", &config.isns_port);
@@ -151,6 +153,11 @@ int main(int argc, char *argv[])
 			break;
 		case 'f':
 			daemon = false;
+			break;
+		case 's':
+			configsz = sizeof(config.configfs_iscsi_path);
+			strncpy(config.configfs_iscsi_path, optarg, configsz);
+			config.configfs_iscsi_path[configsz - 1] = '\0';
 			break;
 		case 'v':
 			printf(PROGNAME " version " TARGET_ISNS_VERSION "\n");
@@ -171,6 +178,9 @@ int main(int argc, char *argv[])
 		fprintf(stderr,
 			"Error: configfs is not mounted or the "
 			"target and iSCSI modules are not loaded.\n");
+		fprintf(stderr,
+			"Error: %s missing.\n",
+			config.configfs_iscsi_path);
 		exit(EXIT_FAILURE);
 	}
 

--- a/src/util.c
+++ b/src/util.c
@@ -13,6 +13,7 @@
 #include <stdio.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include "configfs.h"
 
 #define PIDFILE		"/run/target-isns.pid"
 #define CONFFILE	"/etc/target-isns.conf"
@@ -42,6 +43,7 @@ int conffile_read(void)
 	memset(&config, 0, sizeof(config));
 	config.log_level = LOG_INFO;
 	config.isns_port = ISNS_PORT;
+	strcpy(config.configfs_iscsi_path, CONFIGFS_ISCSI_PATH);
 
 	if ((file = fopen(CONFFILE, "r")) == NULL) {
 		log_print(LOG_ERR, "Could not read " CONFFILE);
@@ -98,6 +100,11 @@ int conffile_read(void)
 				config.log_level = LOG_INFO;
 			else if (streq(value, "debug"))
 				config.log_level = LOG_DEBUG;
+		} else if (streq(key, "configfs_iscsi_path")) {
+			const size_t sz = sizeof(config.configfs_iscsi_path);
+
+			strncpy(config.configfs_iscsi_path, value, sz);
+			config.configfs_iscsi_path[sz - 1] = '\0';
 		}
 	}
 	fclose(file);

--- a/src/util.h
+++ b/src/util.h
@@ -13,6 +13,7 @@ struct {
 	char isns_server[64];
 	uint16_t isns_port;
 	int log_level;
+	char configfs_iscsi_path[256];
 } config;
 
 void pidfile_create(void);

--- a/target-isns.conf
+++ b/target-isns.conf
@@ -11,3 +11,6 @@
 # Log verbosity: info, debug.
 # This parameter is optional.
 # log_level = info
+
+# Configfs path for iscsi.
+# configfs_iscsi_path = /sys/kernel/config/target/iscsi


### PR DESCRIPTION
Provide an alternate configfs-iscsi-path for testing varied configs.

Add the configfs_iscsi_path field to target-isns.conf as well as
the new command line options -s and --configfs-iscsi-path.

Signed-off-by: Kyle Fortin <kyle.fortin@oracle.com>