### PR TITLE
Update target-isns man page for configfs_iscsi_path

### DIFF
--- a/target-isns.8
+++ b/target-isns.8
@@ -27,6 +27,9 @@ increase the debugging level (implies \fB\-\-foreground\fR)
 \fB\-f\fR, \fB\-\-foreground\fR
 run in the foreground
 .TP
+\fB\-s\fR, \fB\-\-configfs-iscsi-path\fR=\fI\/PATH\/\fR
+use alternate sys configfs iscsi path
+.TP
 \fB\-v\fR, \fB\-\-version\fR
 print version information and exit
 .TP
@@ -46,6 +49,9 @@ set the port number of the iSNS server (default iSNS port number is 3205)
 .TP
 \fB\/log_level\fR=[\fI\/info\fR\/|\fI\/debug\fR]
 set the log level (default is info)
+.TP
+\fB\/configfs_iscsi_path\fR=\fI\/PATH\fR
+set the configfs path for iscsi (default is /sys/kernel/config/target/iscsi)
 .SH
 BUGS
 .PP


### PR DESCRIPTION
Add -s and --configfs-iscsi-path command line options as well as the
/etc/target-isns.conf configfs_iscsi_path option.

Signed-off-by: Kyle Fortin <kyle.fortin@oracle.com>