### PR TITLE
Register the iSCSI alias attribute

### DIFF
--- a/documentation/testing.md
+++ b/documentation/testing.md
@@ -40,9 +40,11 @@ containing a single target portal group:
 
     $ mkdir -p fake-iscsi-path/iqn.2018-01.org.example:disk1
     $ mkdir -p fake-iscsi-path/iqn.2018-01.org.example:disk1/tpgt_1
+    $ echo 1 > fake-iscsi-path/iqn.2018-01.org.example:disk1/tpgt_1/enable
     $ mkdir -p fake-iscsi-path/iqn.2018-01.org.example:disk1/tpgt_1/np
     $ mkdir -p fake-iscsi-path/iqn.2018-01.org.example:disk1/tpgt_1/np/0.0.0.0:3260
-    $ echo 1 > fake-iscsi-path/iqn.2018-01.org.example:disk1/tpgt_1/enable
+    $ mkdir -p fake-iscsi-path/iqn.2018-01.org.example:disk1/tpgt_1/param
+    $ echo 'LIO Target' > fake-iscsi-path/iqn.2018-01.org.example:disk1/tpgt_1/param/TargetAlias
 
 Then, you can start target-isns with the `--configfs-iscsi-path`
 option pointing to the fake configfs hierarchy:

--- a/src/configfs.h
+++ b/src/configfs.h
@@ -27,11 +27,13 @@ struct target {
 struct tpg {
 	struct list_node node;  /* Member of a target->tpgs list */
 	uint16_t tag;
+	char alias[ISCSI_ALIAS_SIZE];
 	bool enabled;
 	bool exists;
 	struct list_head portals;
 	int watch_fd;
 	int np_watch_fd;
+	int param_watch_fd;
 };
 
 struct portal {
@@ -61,6 +63,8 @@ void configfs_show(void);
 void configfs_inotify_events_handle(void);
 
 struct target *target_find(const char *target_name);
+
+char *target_get_alias(const struct target *tgt);
 
 struct portal *portal_find(int af, const char *ip_addr, uint16_t port);
 

--- a/src/isns.c
+++ b/src/isns.c
@@ -566,6 +566,8 @@ static int isns_target_register(const struct target *target)
 		/* Register the iSCSI target. */
 		length += isns_tlv_set_string(&tlv, ISNS_ATTR_ISCSI_NAME,
 					      tgt->name);
+		length += isns_tlv_set_string(&tlv, ISNS_ATTR_ISCSI_ALIAS,
+					      target_get_alias(target));
 		length += isns_tlv_set(&tlv, ISNS_ATTR_ISCSI_NODE_TYPE,
 				       sizeof(node), &node);
 		isns_target_register_flush(&tlv, &buf[0], sizeof(buf),

--- a/src/isns_proto.h
+++ b/src/isns_proto.h
@@ -12,9 +12,10 @@
 
 #include <inttypes.h>
 
-#define ISCSI_NAME_SIZE	224
-#define ISNS_PORT	3205
-#define ISNS_ALIGN	4
+#define ISCSI_NAME_SIZE	  224
+#define ISCSI_ALIAS_SIZE  256
+#define ISNS_PORT         3205
+#define ISNS_ALIGN        4
 
 struct isns_hdr {
 	uint16_t version;


### PR DESCRIPTION
The target alias is a user-friendly string associated with the iSCSI
qualified name.

In LIO, the target alias is not a parameter of the target (there is no
target parameter), but a parameter of the TPG. Because several TPGs
may be associated with a given target, conflicting "TargetAlias"
parameters may exist. The logic implemented in this patch is to select
the first target alias encountered which is different from the default
target alias in LIO ("LIO Target"). If no custom target alias is
found, the default target alias is selected.

This patch fixes issue #48.

Signed-off-by: Christophe Vu-Brugier <cvubrugier@fastmail.fm>