### PR TITLE
Fix compile error with GCC 10

### DIFF
--- a/src/configfs.c
+++ b/src/configfs.c
@@ -60,6 +60,8 @@ LIST_HEAD(portals);
 static int inotify_fd = -1;
 static const char LIO_TARGET_ALIAS[] = "LIO Target";
 
+struct config config;
+
 bool configfs_iscsi_path_exists(void)
 {
 	DIR *dir = opendir(config.configfs_iscsi_path);

--- a/src/util.h
+++ b/src/util.h
@@ -9,12 +9,14 @@
 
 #include <inttypes.h>
 
-struct {
+struct config {
 	char isns_server[64];
 	uint16_t isns_port;
 	int log_level;
 	char configfs_iscsi_path[256];
-} config;
+};
+
+extern struct config config;
 
 void pidfile_create(void);
 


### PR DESCRIPTION
There were multiple definitions of the config variable.

Signed-off-by: Maurizio Lombardi <mlombard@redhat.com>