### PR TITLE
Fix gcc-10 warning about zero-length arrays.

### DIFF
--- a/src/isns_proto.h
+++ b/src/isns_proto.h
@@ -24,13 +24,13 @@ struct isns_hdr {
 	uint16_t flags;
 	uint16_t transaction;
 	uint16_t sequence;
-	uint32_t pdu[0];
+	uint32_t pdu[];
 } __attribute__ ((packed));
 
 struct isns_tlv {
 	uint32_t tag;
 	uint32_t length;
-	uint32_t value[0];
+	uint32_t value[];
 } __attribute__ ((packed));
 
 /* X-macro describing iSNSP commands and responses (4.1.3) */


### PR DESCRIPTION
There are two zero-length arrays used, in struct
isns_hdr and struct isns_tlv, that are really meant
as place-holders for allocated arrays. These need
to be declared as empty arrays instead of zero-
length arrays, since this is the accepted way
of handling such data these days.

This fixes a gcc-10 warning that looks like:

In function ‘isns_rsp_handle’,
inlined from ‘isns_handle’ at .../src/isns.c:789:3:
.../src/isns.c:724:34: error: writing 1 byte into a region of size 0 [-Werror=stringop-overflow=]
724 |    *((char *) tlv->value + slen) = '\0';
  |                                  ^
.../src/isns.c: In function ‘isns_handle’:
.../src/isns_proto.h:33:11: note: at offset 0 to object ‘value’ with size 0 declared here
33 |  uint32_t value[0];
  |           ^